### PR TITLE
Add back InfiniteLine and refactor Component options

### DIFF
--- a/src/Components/Grid.ts
+++ b/src/Components/Grid.ts
@@ -41,13 +41,13 @@ const fragmentShader = `
   }
 `;
 
-type GridProps = {
+type GridOptions = {
   cellSize?: number;
   pointRadius?: number;
   pointColor?: Color;
 };
 
-const defaultGridProps: GridProps = {
+const defaultGridOptions: GridOptions = {
   cellSize: 50,
   pointRadius: 1.5,
   pointColor: new Color(0xe1e1e1),
@@ -56,10 +56,13 @@ const defaultGridProps: GridProps = {
 class Grid extends Component {
   draggable = undefined;
 
-  constructor(props: GridProps = defaultGridProps) {
+  constructor(options?: GridOptions) {
     super();
 
-    const { cellSize, pointRadius, pointColor } = props;
+    const { cellSize, pointRadius, pointColor } = {
+      ...defaultGridOptions,
+      ...options,
+    };
 
     const gridGeometry = new PlaneGeometry(
       window.innerWidth,

--- a/src/Components/InfiniteLine.ts
+++ b/src/Components/InfiniteLine.ts
@@ -1,0 +1,65 @@
+import { OrthographicCamera, Vector3 } from "three";
+import { toVector3 } from "../utils";
+import Line, { LineProps } from "./Line";
+import { InputPosition } from "./types";
+
+class InfiniteLine extends Line {
+  constructor(start: InputPosition, end: InputPosition, props?: LineProps) {
+    super(start, end, props);
+    this.frustumCulled = false;
+  }
+
+  _updateGeometry(camera: OrthographicCamera) {
+    const left = camera.position.x + camera.left / camera.zoom;
+    const right = camera.position.x + camera.right / camera.zoom;
+    const top = camera.position.y + camera.top / camera.zoom;
+    const bottom = camera.position.y + camera.bottom / camera.zoom;
+
+    const startVec3 = toVector3(this.start);
+    const endVec3 = toVector3(this.end);
+    const dir = new Vector3().copy(endVec3).sub(startVec3).normalize();
+
+    if (dir.x == 0 && dir.y == 0) return;
+
+    const a = [Infinity, Infinity];
+    const b = [Infinity, Infinity];
+    if (dir.x != 0) {
+      a[0] = (right - startVec3.x) / dir.x;
+      b[0] = (left - startVec3.x) / dir.x;
+    }
+    if (dir.y != 0) {
+      a[1] = (top - startVec3.y) / dir.y;
+      b[1] = (bottom - startVec3.y) / dir.y;
+    }
+
+    const closestA = a.reduce((prev, curr) =>
+      Math.abs(prev) < Math.abs(curr) ? prev : curr
+    );
+    const closestB = b.reduce((prev, curr) =>
+      Math.abs(prev) < Math.abs(curr) ? prev : curr
+    );
+
+    this.geometry.attributes.instanceStart.setXYZ(
+      0,
+      startVec3.x + dir.x * closestA,
+      startVec3.y + dir.y * closestA,
+      0
+    );
+
+    this.geometry.attributes.instanceEnd.setXYZ(
+      0,
+      startVec3.x + dir.x * closestB,
+      startVec3.y + dir.y * closestB,
+      0
+    );
+
+    this.geometry.attributes.instanceStart.needsUpdate = true;
+    this.geometry.attributes.instanceEnd.needsUpdate = true;
+  }
+
+  update(camera: OrthographicCamera) {
+    this._updateGeometry(camera);
+  }
+}
+
+export default InfiniteLine;

--- a/src/Components/Line.ts
+++ b/src/Components/Line.ts
@@ -4,13 +4,13 @@ import { toVector3 } from "../utils";
 import { Component } from "./interfaces";
 import { InputPosition } from "./types";
 
-export type LineProps = {
+export type LineOptions = {
   color?: number;
   lineWidth?: number;
 };
 
-export const defaultLineProps: LineProps = {
-  color: 0x000000,
+export const defaultLineOptions: LineOptions = {
+  color: 0x080007,
   lineWidth: 4,
 };
 
@@ -19,12 +19,10 @@ class Line extends Component {
   end: InputPosition;
   draggable = undefined;
 
-  constructor(
-    start: InputPosition,
-    end: InputPosition,
-    { color, lineWidth }: LineProps = defaultLineProps
-  ) {
+  constructor(start: InputPosition, end: InputPosition, options?: LineOptions) {
     super();
+    const { color, lineWidth } = { ...defaultLineOptions, ...options };
+
     this.start = start;
     this.end = end;
 

--- a/src/Components/Plot.ts
+++ b/src/Components/Plot.ts
@@ -3,12 +3,20 @@ import { parse } from "mathjs";
 import { Line2, LineGeometry, LineMaterial } from "three-fatline";
 import { Component } from "./interfaces";
 
-type PointOptions = {
+type PlotOptions = {
   numPoints?: number;
   dashed?: boolean;
   lineWidth?: number;
   color?: number;
   coefficients?: Coefficients;
+};
+
+const defaultPlotOptions = {
+  numPoints: 2500,
+  dashed: false,
+  lineWidth: 1,
+  color: 0xff0000,
+  coefficients: {},
 };
 
 type Coefficients = {
@@ -28,17 +36,17 @@ class Plot extends Component {
   private RENDERTHRESHOLDX = 300;
   private RENDERTHRESHOLDZOOM = 0.3;
 
-  constructor(
-    func: string,
-    {
+  constructor(func: string, options?: PlotOptions) {
+    super();
+
+    const {
       numPoints = 2500,
       dashed = false,
       lineWidth = 1,
       color = 0xff0000,
       coefficients = {},
-    }: PointOptions
-  ) {
-    super();
+    } = { ...defaultPlotOptions, ...options };
+
     const minX = (-PLOTRANGE / 1) * 2 + 0;
     const maxX = (PLOTRANGE / 1) * 2 + 0;
     const initialCurve = new CatmullRomCurve3(

--- a/src/Components/Point.ts
+++ b/src/Components/Point.ts
@@ -9,18 +9,21 @@ type PointOptions = {
   draggable?: Draggable;
 };
 
+const defaultPointOptions = {
+  color: "#FAA307",
+  draggable: undefined,
+  decimals: 1,
+  label: false,
+};
+
 class Point extends Component {
-  constructor(
-    x = 0,
-    y = 0,
-    {
-      color = "#FAA307",
-      draggable = undefined,
-      decimals = 1,
-      label = false,
-    }: PointOptions
-  ) {
+  constructor(x = 0, y = 0, options?: PointOptions) {
     super();
+    const { color, draggable, decimals, label } = {
+      ...defaultPointOptions,
+      ...options,
+    };
+
     // set position of the point instance
     this.draggable = draggable;
     // create a circle geometry

--- a/src/Components/Text.ts
+++ b/src/Components/Text.ts
@@ -12,23 +12,28 @@ type TextOptions = {
   anchorX?: "left" | "center" | "right";
 };
 
+const defaultTextOptions = {
+  position: [0, 0] as [number, number],
+  color: "black",
+  fontSize: 30,
+  anchorX: "left",
+  anchorY: "bottom",
+};
+
 type TroikaTextType = InstanceType<typeof TroikaText>;
 
 class Text extends Component {
   draggable = undefined;
   renderText: TroikaTextType;
 
-  constructor(
-    text: string,
-    {
-      position = [0, 0],
-      color = "black",
-      fontSize = 30,
-      anchorX = "left",
-      anchorY = "bottom",
-    }: TextOptions
-  ) {
+  constructor(text: string, options?: TextOptions) {
     super();
+
+    const { position, color, fontSize, anchorX, anchorY } = {
+      ...defaultTextOptions,
+      ...options,
+    };
+
     const renderText = new TroikaText();
     const pos = toVector3(position);
     renderText.text = text;


### PR DESCRIPTION
With this PR you don't have to provide an empty object if you want to use the default options. The default option values of a component is now moved into a separate variable.