### PR TITLE
Fix timer issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "parcel": "^2.9.3",
     "prettier": "^2.8.8",
     "process": "^0.11.10",
+    "stats.js": "^0.17.0",
     "ts-loader": "^9.4.3",
     "typescript": "^5.1.3",
     "webpack": "^5.88.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5351,6 +5351,11 @@ stable@^0.1.8:
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
+stats.js@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/stats.js/-/stats.js-0.17.0.tgz#b1c3dc46d94498b578b7fd3985b81ace7131cc7d"
+  integrity sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==
+
 statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"


### PR DESCRIPTION
Optimize graphica further by:

- Storing an array of update components instead of traversing on each frame
- Storing an update function instead of creating a new one on each frame
- Only check if the timer should be started at startup, implement a startClock and stopClock instead.

Additionally implemented an FPS counter in development mode.