### PR TITLE
Fix of positioning and overflow for LegendBoxWrapper

### DIFF
--- a/style.css
+++ b/style.css
@@ -131,15 +131,14 @@ body {
 }
 
 .legendBox-wrapper {
-  position: sticky;
+  position: absolute;
   width: 260px;
   max-height: 170px;
   background-color: #fae493;
   border-radius: 6px;
   border-style: solid;
   border-width: 3px;
-  overflow-y: scroll;
-  overflow-x: scroll;
+  overflow: auto;
   padding-bottom: 6px;
 }
 


### PR DESCRIPTION
Styling fixes to LegendBoxWrapper:
- Set position to absolute instead of sticky
- Set overflow to auto instead of having individual scrolls for overflow_x and overflow_y

Closes #83 
