### PR TITLE
86 legendbox refinement

### DIFF
--- a/src/Components/LegendBox.ts
+++ b/src/Components/LegendBox.ts
@@ -118,8 +118,7 @@ class LegendBox implements GuiComponent {
     let textToDisplay = "";
 
     if (typeof element === "string") {
-      textToDisplay =
-        element + ": " + this.replaceStateNamesWithValues(element);
+      textToDisplay = this.replaceStateNamesWithValues(element);
     } else if (element instanceof State) {
       textToDisplay =
         element.getStateName() + ": " + element.getState().toFixed(1);

--- a/src/Components/LegendBox.ts
+++ b/src/Components/LegendBox.ts
@@ -85,6 +85,10 @@ class LegendBox implements GuiComponent {
   private processElement(element: Component | string | State<number>) {
     const functionContainer = document.createElement("div");
     functionContainer.className = "function-container";
+
+    if (element instanceof State && !element.inLegend) {
+      return;
+    }
     const icon = this.createIcon(element);
     functionContainer.appendChild(icon);
 

--- a/src/Components/Point.ts
+++ b/src/Components/Point.ts
@@ -18,6 +18,9 @@ type PointOptions = {
   color?: string;
   draggable?: Draggable;
   dragListeners?: ((point: Point) => void)[];
+  customName?: string;
+  showName?: boolean;
+  legendCoordinates?: string;
 };
 
 const defaultPointOptions = {
@@ -26,23 +29,38 @@ const defaultPointOptions = {
   decimals: 1,
   label: false,
   dragListeners: [],
+  showName: true,
+  legendCoordinates: "",
 };
 
 class Point extends Component implements Collider, DragListener<Point> {
   private pointName: string | undefined;
+  private showName: boolean;
+  private legendCoordinates: string;
   private static pointCounter = 0;
   static emitter = new EventEmitter();
   private color: string;
   dragListeners: ((point: Point) => void)[];
   constructor(x = 0, y = 0, options?: PointOptions) {
     super();
-    const { color, draggable, decimals, label, dragListeners } = {
+    const {
+      color,
+      draggable,
+      decimals,
+      label,
+      dragListeners,
+      customName,
+      showName,
+      legendCoordinates,
+    } = {
       ...defaultPointOptions,
       ...options,
     };
     //set point name and color
-    this.setPointName();
+    this.setPointName(customName);
     this.color = color;
+    this.showName = showName;
+    this.legendCoordinates = legendCoordinates;
 
     // set position of the point instance
     this.draggable = draggable;
@@ -79,16 +97,18 @@ class Point extends Component implements Collider, DragListener<Point> {
     }
 
     //add name of point
-    const nameText = new Text(this.pointName, {
-      color: "black",
-      fontSize: 18,
-      anchorY: "middle",
-      anchorX: "left",
-      position: [15, 0],
-      responsiveScale: false,
-    });
-    nameText.name = "name";
-    this.add(nameText);
+    if (this.showName) {
+      const nameText = new Text(this.pointName, {
+        color: "black",
+        fontSize: 18,
+        anchorY: "middle",
+        anchorX: "left",
+        position: [15, 0],
+        responsiveScale: false,
+      });
+      nameText.name = "name";
+      this.add(nameText);
+    }
   }
 
   addDragListener(listener: (point: Point) => void) {
@@ -141,19 +161,35 @@ class Point extends Component implements Collider, DragListener<Point> {
   public setPosition(x: number, y: number) {
     this.position.set(x, y, this.position.z);
   }
-  private setPointName() {
-    this.pointName = String.fromCharCode(
-      "A".charCodeAt(0) + Point.pointCounter
-    );
-    Point.pointCounter++;
+  private setPointName(customName?: string) {
+    if (customName) {
+      this.pointName = customName;
+    } else {
+      this.pointName = String.fromCharCode(
+        "A".charCodeAt(0) + Point.pointCounter
+      );
+      Point.pointCounter++;
+    }
   }
+
   public getName(): string {
     return this.pointName as string;
   }
+
   public getDisplayText(): string {
-    return (
-      "(" + this.position.x.toFixed(1) + ", " + this.position.y.toFixed(1) + ")"
-    );
+    if (this.legendCoordinates === "x") {
+      return "(" + this.position.x.toFixed(1) + ")";
+    } else if (this.legendCoordinates === "y") {
+      return "(" + this.position.y.toFixed(1) + ")";
+    } else {
+      return (
+        "(" +
+        this.position.x.toFixed(1) +
+        ", " +
+        this.position.y.toFixed(1) +
+        ")"
+      );
+    }
   }
 
   public hover() {

--- a/src/Components/State.ts
+++ b/src/Components/State.ts
@@ -2,14 +2,28 @@ import EventEmitter from "eventemitter3";
 
 const STATE_CHANGE_EVENT = "stateChange";
 
+type StateOptions = {
+  inLegend?: boolean;
+};
+
+const defaultStateOptions = {
+  inLegend: true,
+};
+
 class State<T> {
   private stateName: string;
   private state: T;
   private emitter: EventEmitter;
+  public inLegend: boolean;
 
-  constructor(stateName: string, initialState: T) {
+  constructor(stateName: string, initialState: T, options?: StateOptions) {
+    const { inLegend } = {
+      ...defaultStateOptions,
+      ...options,
+    };
     this.stateName = stateName;
     this.state = initialState;
+    this.inLegend = inLegend;
     this.emitter = new EventEmitter();
   }
 

--- a/style.css
+++ b/style.css
@@ -132,6 +132,8 @@ body {
 
 .legendBox-wrapper {
   position: absolute;
+  top: 30px;
+  left: 30px;
   width: 260px;
   max-height: 170px;
   background-color: #fae493;


### PR DESCRIPTION
Make requested changes to LegendBox (and thereby Point):
- Add 3 props to Point: "showName", "customName" and "legendCoordinates" such that user can give point a custom name, decide to show/hide the point name from grid and decide which coordinates to display in LegendBox (only x, only y or both)
- Add prop to State: "inLegend" such that states can be used by expressions in LegendBox without being displayed as an own element in LegendBox
- Fix that for Latex in LegendBox, only the expression with inserted values appears

<img width="694" alt="Skjermbilde 2024-08-02 kl  16 53 03" src="https://github.com/user-attachments/assets/cea29803-1e95-4626-96cb-471e4f45a8c3">
<img width="536" alt="Skjermbilde 2024-08-02 kl  16 53 36" src="https://github.com/user-attachments/assets/8a97c74f-9dce-4aa4-aaac-f194c72480e1">
<img width="271" alt="Skjermbilde 2024-08-02 kl  16 54 12" src="https://github.com/user-attachments/assets/18237232-5658-4572-9529-13a581f0751d">

Closes #86 